### PR TITLE
Fix size of hide button in navigation

### DIFF
--- a/docs/sg.scss
+++ b/docs/sg.scss
@@ -296,7 +296,7 @@ $font-stack: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helveti
   margin: 0;
   padding: 0;
 
-  font-size: 1em;
+  font-size: 1rem;
   line-height: 1;
   color: #fff;
 


### PR DESCRIPTION
This will make sure the button stays at the same size even if the body sets a different font size.